### PR TITLE
Added a default-empty operations hash with its type set. 

### DIFF
--- a/lib/MSSQLVDB_obj.pm
+++ b/lib/MSSQLVDB_obj.pm
@@ -73,7 +73,10 @@ sub new {
                     }
             },
             "source" => {
-                    "type" => "MSSqlVirtualSource"
+                    "type" => "MSSqlVirtualSource",
+                    "operations" => {
+                        "type" => "VirtualSourceOperations"
+                    }
             },
             "timeflowPointParameters" => {
                 "type" => "TimeflowPointSemantic",


### PR DESCRIPTION
Without this, an MSSQL provision with hooks such as configuraClone will create an operations hash without a type, resulting in a provisioning error.