### PR TITLE
Fixed typo in dx_ctl_env help and Skip executable check for password script in windows

### DIFF
--- a/bin/dx_ctl_env.pl
+++ b/bin/dx_ctl_env.pl
@@ -503,7 +503,7 @@ __DATA__
 
  dx_ctl_env [ -engine|d <delphix identifier> | -all ] [ -configfile file ]
             [ -name env_name | -reference reference ]
-            -acton <enable|disable|refresh|adduser|addrepo|adddatabase|addlistener
+            -action <enable|disable|refresh|adduser|addrepo|adddatabase|addlistener
                    |deleteuser|deleterepo|deletedatabase|deletelistener|updatehost>
             [-dbname dbname]
             [-instancename instancename]

--- a/lib/Engine.pm
+++ b/lib/Engine.pm
@@ -510,10 +510,13 @@ sub extended_password {
       return 1;
     }
 
-    if (! -x "$engine_config->{passwordscript}") {
-      print "Password script $engine_config->{passwordscript} is not executable\n";
-      logger($self->{_debug}, "Password script $engine_config->{passwordscript} is not executable");
-      return 1;
+    my $osname = $^O;
+    if ( $osname ne 'MSWin32' ) {
+      if (! -x "$engine_config->{passwordscript}") {
+        print "Password script $engine_config->{passwordscript} is not executable\n";
+        logger($self->{_debug}, "Password script $engine_config->{passwordscript} is not executable");
+        return 1;
+      }
     }
 
     my $out = qx|$line|;


### PR DESCRIPTION
# Problem:
1. Typo in help of dx_ctl_env file
2. Password script functionality fails if .ps1 scripts are used. Existing functionality checks if the script is executable and fails if its not. This is valid for UNIX platform but does not return correct code for windows(.ps1) file. It does return correct code for .bat file. Executable check is not as such valid for windows.

# Solution:
Fix typo and skip executable check if environment is windows

