### PR TITLE
Made changes to dx_ctl_users.pl and dxusers.csv.example to include th…

### DIFF
--- a/bin/dx_ctl_users.pl
+++ b/bin/dx_ctl_users.pl
@@ -515,15 +515,16 @@ Add user to one engine using users file and profile file
 
 Example csv user file:
 
- # operation,username,first_name,last_name,email address,work_phone,home_phone,cell_phone,type(NATIVE|LDAP),principal_credential,password,admin_priv,js_user
- # comment - create a new user with Delphix authentication
- C,testuser,Test,User,test.user@test.mail.com,,555-222-222,,NATIVE,,password,Y
- # comment - create a new user with LDAP
- C,testuser2,Test,User2,test.user@test.mail.com,555-111-111,555-222-222,555-333- 333,LDAP,"testuser@test.domain.com",,Y
- # update existing user - non-empty values will be updated, password can't be modified in this version
- U,user11,FirstName,LastName,newemail@test.com,,,,,,, U,testuser,Test,User,test.user@test.com,,555-222-333,,NATIVE,,password,Y
- # delete user
- D,testuser2,,,,,,,,,,
+#operation,username,first_name,last_name,email address,work_phone,home_phone,cell_phone,type(NATIVE|LDAP),principal_credential,password,admin_priv,js_user,timeout,apiUser
+# comment - create a new user with Delphix authentication
+C,testuser,Test,User,test.user@test.mail.com,,555-222-222,,NATIVE,,password,Y,N,60,N
+# comment - create a new user with LDAP
+C,testuser2,Test,User2,test.user@test.mail.com,555-111-111,555-222-222,555-333-333,LDAP,"testuser@test.domain.com",,Y,N,60,N
+# update existing user - non-empty values will be updated, password can't be modified in this version
+U,user11,FirstName,LastName,newemail@test.com,,,,,,,
+U,testuser,Test,User,test.user@test.com,,555-222-333,,NATIVE,,password,,Y
+# delete user
+D,testuser2,,,,,,,,,,,
 
 Example csv profile file:
 

--- a/bin/dxusers.csv.example
+++ b/bin/dxusers.csv.example
@@ -1,10 +1,11 @@
-#operation,username,first_name,last_name,email address,work_phone,home_phone,cell_phone,type(NATIVE|LDAP),principal_credential,password,admin_priv,js_user,timeout
+#operation,username,first_name,last_name,email address,work_phone,home_phone,cell_phone,type(NATIVE|LDAP),principal_credential,password,admin_priv,js_user,timeout,apiUser
 # comment - create a new user with Delphix authentication
-C,testuser,Test,User,test.user@test.mail.com,,555-222-222,,NATIVE,,password,Y,60
+C,testuser,Test,User,test.user@test.mail.com,,555-222-222,,NATIVE,,password,Y,N,60,N
 # comment - create a new user with LDAP
-C,testuser2,Test,User2,test.user@test.mail.com,555-111-111,555-222-222,555-333-333,LDAP,"testuser@test.domain.com",,Y
+C,testuser2,Test,User2,test.user@test.mail.com,555-111-111,555-222-222,555-333-333,LDAP,"testuser@test.domain.com",,Y,N,60,N
 # update existing user - non-empty values will be updated, password can't be modified in this version
 U,user11,FirstName,LastName,newemail@test.com,,,,,,,
 U,testuser,Test,User,test.user@test.com,,555-222-333,,NATIVE,,password,,Y
 # delete user
-D,testuser2,,,,,,,,,,
+D,testuser2,,,,,,,,,,,
+


### PR DESCRIPTION
…e apiUser option in the example

<!--
### Background
Made changes to dx_ctl_users.pl and dxusers.csv.example to include the apiUser option in the example
-->
### Problem
API User option is not documented in  dxusers.csv.example both in help section as well as in the dxusers.csv.example file
<!--
### Evaluation
NA as this is a documentation fix
### Solution
API User option is now documented in  dxusers.csv.example both in help section as well as in the dxusers.csv.example file
### Testing Done
Yes.
### Implementation
Code has been tested and it is working fine
### Notes to Reviewers
Dcoumentation fix for an already working executable.
We are just including the documentation in the help section and in the csv example file
### Deployment Plan
NA as its a simple documentation fix
-->
<!--
### Future Work
NA
### Bonus
NA
