### PR TITLE
Enhance dx_get_env to list OS users along with other details 

### DIFF
--- a/bin/dx_get_env.pl
+++ b/bin/dx_get_env.pl
@@ -108,6 +108,7 @@ if (defined($userlist)) {
   $output->addHeader(
     {'Appliance',         20},
     {'Environment Name',  30},
+    {'Environment Users',  30},
     {'Type',              25},
     {'Host name',         30},
     {'User Name',         30},
@@ -133,6 +134,7 @@ else {
     {'Appliance', 20},
     {'Environment Name',  30},
     {'Type',      25},
+    {'Environment Users',  30},
     {'Status',     8},
     {'OS Version', 50}
   );
@@ -251,7 +253,7 @@ for my $engine ( sort (@{$engine_list}) ) {
         $config = $environments->getConfig($envitem, $host_obj);
         $output->addLine(
          $engine,
-         $envname,
+                 $envname,
          $envtype,
          $hostname,
          $user,
@@ -262,6 +264,7 @@ for my $engine ( sort (@{$engine_list}) ) {
       }
     } else {
       my $cluster_nodes;
+      my $user = $environments->getPrimaryUserName($envitem);
       my $host_ref = $environments->getHost($envitem);
       my $hostos;
       if (($host_ref ne 'CLUSTER') && ($host_ref ne 'NA')) {
@@ -285,16 +288,28 @@ for my $engine ( sort (@{$engine_list}) ) {
           $hostos,
           $cluster_nodes
         );
-      } else {
-        $output->addLine(
-          $engine,
-          $environments->getName($envitem),
-          $environments->getType($envitem),
-          $environments->getStatus($envitem),
-          $hostos
-        );
       }
-    }
+      else {
+              $output->addLine(
+                $engine,
+                $environments->getName($envitem),
+                $environments->getType($envitem),
+                '*' . $environments->getPrimaryUserName($envitem),
+                $environments->getStatus($envitem),
+                $hostos
+              );
+              for my $useritem (@{$environments->getEnvironmentNotPrimaryUsers($envitem)}) {
+                      $output->addLine(
+                        '',
+                        '',
+                        '',
+                        $environments->getEnvironmentUserNamebyRef($envitem,$useritem),
+                        '',
+                        ''
+                      );
+              }
+      }
+}
 
     $save_state{$envitem} = $environments->getStatus($envitem);
 
@@ -413,13 +428,13 @@ Display all environments
 
  dx_get_env -d Landshark
 
- Appliance            Reference                      Environment Name               Type                      Status
- -------------------- ------------------------------ ------------------------------ ------------------------- --------
- Landshark5           ORACLE_CLUSTER-11              racattack-cl                   rac                       enabled
- Landshark5           UNIX_HOST_ENVIRONMENT-1        LINUXTARGET                    unix                      enabled
- Landshark5           UNIX_HOST_ENVIRONMENT-44       LINUXSOURCE                    unix                      enabled
- Landshark5           WINDOWS_HOST_ENVIRONMENT-48    WINDOWSTARGET                  windows                   enabled
- Landshark5           WINDOWS_HOST_ENVIRONMENT-49    WINDOWSSOURCE                  windows                   enabled
+ Appliance            Environment Name               Type                      Environment Users       Status          OS Version
+ -------------------- ------------------------------ ------------------------- ----------------------- --------------- --------------------------------------------------------
+ Landshark5           racattack-cl                   rac                       *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
+ Landshark5           LINUXTARGET                    unix                      *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
+ Landshark5           LINUXSOURCE                    unix                      *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
+ Landshark5           WINDOWSTARGET                  windows                   *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
+ Landshark5           WINDOWSSOURCE                  windows                   *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
 
 Display all environments with repositories list
 
@@ -446,6 +461,30 @@ Display all environments with repositories list
                                                      MSSQLSERVER
                                                      MSSQL2012
 
+Display all environments with cluster list
+
+dx_get_env -d Landshark -cluster
+
+ Appliance            Environment Name               Type                      Status          OS Version                                               Hostname
+ -------------------- ------------------------------ ------------------------- --------------- -------------------------------------------------------- ---------------------
+ Landshark5           racattack-cl                   rac                       enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server1;10.***.**.01
+ Landshark5           LINUXTARGET                    unix                      enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server2;10.***.**.02
+ Landshark5           LINUXSOURCE                    unix                      enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server3;10.***.**.03
+ Landshark5           WINDOWSTARGET                  windows                   enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server4;10.***.**.04
+ Landshark5           WINDOWSSOURCE                  windows                   enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server5;10.***.**.05
+
+
+Display all environments with user list
+
+dx_get_env -d Landshark -userlist
+
+ Appliance            Environment Name               User name               Status          Auth Type
+ -------------------- ------------------------------ ----------------------- --------------- ---------------
+ Landshark5           racattack-cl                   *delphix                enabled         password
+ Landshark5           LINUXTARGET                    *delphix                enabled         password
+ Landshark5           LINUXSOURCE                    *delphix                enabled         systemkey
+ Landshark5           WINDOWSTARGET                  *delphix                enabled         password
+ Landshark5           WINDOWSSOURCE                  *delphix                enabled         systemkey
 
 
 =cut


### PR DESCRIPTION
<!--
### Background
Enhanced dx_get_env to display environments(OS) users and updated the respective help section. Also updated help section for cluster and userlist options
-->
### Problem
There is no dxtoolkit command to display the OS user(s) associated with an environment. There was a case where a customer was trying to use "dx_ctl_dsource" to link a MSSQL dSource but it failed with error (os user not found)
<!--
### Evaluation
Completed testing by running dx_get_env to display os users along with other details and also tested the help option for updated section
### Solution
The script dx_get_env is now enhanced to list the os users along with existing other details. The existing command now displays additional column in the report "Environment Users"
### Testing Done
Yes.

Help command output
perl dx_get_env.pl -help
SYNOPSIS
     dx_get_env [-engine|d <delphix identifier> | -all ]
                [-name env_name | -reference reference ]
                [-backup]
                [-replist ]
                [-cluster ]
                [-format csv|json ]
                [-help|? ]
                [-debug ]

DESCRIPTION
    Get the information about host environment.

ARGUMENTS
    Delphix Engine selection - if not specified a default host(s) from
    dxtools.conf will be used.

    -engine|d Specify Delphix Engine name from dxtools.conf file
    -all Display databases on all Delphix appliance
    -configfile file Location of the configuration file. A config file
    search order is as follow: - configfile parameter - DXTOOLKIT_CONF
    variable - dxtools.conf from dxtoolkit location

  Filters
    -name Environment Name
    -reference Environment reference

OPTIONS
    -backup Display dxtoolkit commands to recreate environments ( support
    for SI Oracle / MS SQL )
    -replist Display repository list (Orcle Home / MS SQL instance / etc )
    for environment
    -cluster Print ; segrageted list of cluster nodes from the environment
    into a new column called cluster nodes
    -format Display output in csv or json format If not specified pretty
    formatting is used.
    -help Print this screen
    -debug Turn on debugging

EXAMPLES
    Display all environments

     dx_get_env -d Landshark

     Appliance            Environment Name               Type                      Environment Users       Status          OS Version
     -------------------- ------------------------------ ------------------------- ----------------------- --------------- --------------------------------------------------------
     Landshark5           racattack-cl                   rac                       *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
     Landshark5           LINUXTARGET                    unix                      *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
     Landshark5           LINUXSOURCE                    unix                      *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
     Landshark5           WINDOWSTARGET                  windows                   *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)
     Landshark5           WINDOWSSOURCE                  windows                   *delphix                enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)

    Display all environments with repositories list

     dx_get_env -d Landshark -replist

     Appliance            Environment Name               Repository list
     -------------------- ------------------------------ ------------------------------
     Landshark            racattack
                                                         /u01/app/oracle/11.2.0.4/racho
     Landshark            LINUXTARGET
                                                         agilemasking
                                                         LINUXTARGET
                                                         /u01/app/oracle/product/11.2.0
     Landshark            LINUXSOURCE
                                                         webapp
                                                         agilemasking
                                                         LINUXSOURCE
                                                         /u01/app/oracle/product/11.2.0
     Landshark            envtest
                                                         /u01/app/oracle/11.2.0.4/db1
     Landshark            WINDOWSSOURCE
                                                         MSSQLSERVER
     Landshark            WINDOWSTARGET
                                                         MSSQLSERVER
                                                         MSSQL2012

    Display all environments with cluster list

    dx_get_env -d Landshark -cluster

     Appliance            Environment Name               Type                      Status          OS Version                                               Hostname
     -------------------- ------------------------------ ------------------------- --------------- -------------------------------------------------------- ---------------------
     Landshark5           racattack-cl                   rac                       enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server1;10.***.**.01
     Landshark5           LINUXTARGET                    unix                      enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server2;10.***.**.02
     Landshark5           LINUXSOURCE                    unix                      enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server3;10.***.**.03
     Landshark5           WINDOWSTARGET                  windows                   enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server4;10.***.**.04
     Landshark5           WINDOWSSOURCE                  windows                   enabled         Red Hat Enterprise Linux Server release 7.9 (Maipo)      server5;10.***.**.05

    Display all environments with user list

    dx_get_env -d Landshark -userlist

     Appliance            Environment Name               User name               Status          Auth Type
     -------------------- ------------------------------ ----------------------- --------------- ---------------
     Landshark5           racattack-cl                   *delphix                enabled         password
     Landshark5           LINUXTARGET                    *delphix                enabled         password
     Landshark5           LINUXSOURCE                    *delphix                enabled         systemkey
     Landshark5           WINDOWSTARGET                  *delphix                enabled         password
     Landshark5           WINDOWSSOURCE                  *delphix                enabled         systemkey

	 
	 
### Implementation
Code has been tested and it is working fine
### Notes to Reviewers
Script has been enhanced to list the os users along with existing other details and also the help section is updated for cluster and userlist options
### Deployment Plan
The code has been tested for the respective options and validated the output
-->
<!--
### Future Work
NA
### Bonus
The help section is updated for cluster and userlist options in the script dx_get_env